### PR TITLE
Improve the UI a bit

### DIFF
--- a/apollo-cli/src/main/kotlin/com/apollographql/cli/InstallCommand.kt
+++ b/apollo-cli/src/main/kotlin/com/apollographql/cli/InstallCommand.kt
@@ -60,17 +60,27 @@ internal class InstallCommand : CliktCommand(
           found = true
           if (!readText().contains(source)) {
             appendText("\n")
+            println("Added init snippet to $absolutePath ✅")
             appendText(source)
           }
         }
       }
     }
 
+    println()
+    println("👋 Welcome to apollo-kotlin-cli!")
+    println()
+    println("- apollo-kotlin-cli helps you work with GraphQL and Kotlin.")
+    println("- Quickstart: apollo-kotlin-cli --help")
+    println("- Learn more at https://github.com/apollographql/apollo-kotlin-cli.")
+    println()
+
     if (!found) {
       println("Cannot detect your shell. Add the following to your init scripts:")
       println(source)
     } else {
-      println("Open a new terminal or run the command below to start using apollo-kotlin-cli")
+      println("Open a new terminal or run the command below to start using apollo-kotlin-cli:")
+      println()
       println(source)
     }
   }


### PR DESCRIPTION
```
apollo-kotlin-cli has been installed in '/Users/mbonnin/.apollo-kotlin-cli' ✅
Added init snippet to /Users/mbonnin/.bashrc

👋 Welcome to apollo-kotlin-cli!

- apollo-kotlin-cli helps you work with GraphQL and Kotlin.
- Quickstart: apollo-kotlin-cli --help
- Learn more at https://github.com/apollographql/apollo-kotlin-cli.

Open a new terminal or run the command below to start using apollo-kotlin-cli:

source "/Users/mbonnin/.apollo-kotlin-cli/init.sh"
```